### PR TITLE
Resolved plugin not working on build due to incomplete regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
+        "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1371,6 +1372,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
@@ -2215,6 +2226,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tailwindcss": "^4.1.12"
   },
   "devDependencies": {
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/vite-plugin-ban-tags.ts
+++ b/vite-plugin-ban-tags.ts
@@ -1,15 +1,15 @@
 import type { Plugin } from 'vite';
 
 
-const fileRegex: RegExp = /!\/\.(ts|tsx|js|jsx)$\//
-const aCodeRegex: RegExp = /jsxDEV\(\s*["']a["']/
-const banList: RegExp[] = [aCodeRegex]
+const fileRegex: RegExp = /!\/\.(ts|tsx|js|jsx)$\// /* Note: Might be an issue with node_modules since it isn't ignored when transforming */
+const aCodeRegex: RegExp = /jsx(?:DEV)?\(\s*["']a["']/;
+const banList: RegExp[] = [aCodeRegex];
 
 export default function banTagsPlugin(): Plugin {
     return {
         name: "no-a-tag-plugin",
         transform(code: string, id: string) {
-            if(fileRegex.test(id)) return
+            if(fileRegex.test(id)) return;
             
             for(const item of banList) {
                 if(item.test(code)){


### PR DESCRIPTION
- Fixed incomplete regex resulting in plugin not working on `build`.
- Added `@types/node` to allow for debugging.